### PR TITLE
update port from 5000 to 3001

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -35,6 +35,6 @@ app.get('/', function (req, res) {
  })
 
 //creates the web server
-var server = app.listen(5000, function () {
-   console.log("Express App running at http://127.0.0.1:5000/");
+var server = app.listen(3001, function () {
+   console.log("Express App running at http://127.0.0.1:3001/");
 })


### PR DESCRIPTION
problem: using port 5000 crashes with my local env apps.

solution: updating server application port from 5000 to 3001.

reason: 3000: Commonly used for web development, especially for front-end applications (e.g., React, Vue, or Angular) and back-end services (e.g., Express, Rails in development mode).