### PR TITLE
Adds env file reading to backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,4 @@ dist
 # DS_Store
 .DS_Store
 server/index copy.js
+server/keys.env

--- a/server/index.js
+++ b/server/index.js
@@ -24,13 +24,14 @@ let pantrySchema = new mongoose.Schema({
 
 const Pantry = mongoose.model('Pantry', pantrySchema);
 
+console.log(process.env);
 
-mongoose.connect("MONGOBD_URL", { useNewUrlParser: true, useUnifiedTopology: true })
+mongoose.connect(process.env.MONGO_DB_URL, { useNewUrlParser: true, useUnifiedTopology: true })
    .then(() => console.log('Connected to MongoDB'))
    .catch(err => console.error('Could not connect to Server:', err))
 
 const openai = new OpenAI({
-   apiKey: "YOUR_API_KEY",
+   apiKey: process.env.OPENAI_API_KEY,
    dangerouslyAllowBrowser: false,
  });
 

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "dev": "nodemon index.js",
+    "dev": "nodemon --env-file=keys.env index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "CS 3300 Group 8",


### PR DESCRIPTION
Add the file keys.env in the same directory as the backend index.js, then add your OpenAI key and MongoDB URL as environment variables named as used in index.js. I was simply getting annoyed at having to replace the urls every time. There are technically benefits in terms of being able to use different keys for deployment, but for now, it's just for convenience.